### PR TITLE
Style fix: add -webkit- support for background-clip & remove non-necessary scroll attribute

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -81,6 +81,7 @@ span {
     background: linear-gradient(to right,
             var(--accent-color),
             var(--secondary-color));
+    -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
     font-weight: 700;

--- a/src/routes/MainContent.svelte
+++ b/src/routes/MainContent.svelte
@@ -72,7 +72,6 @@
         width: 100%;
         justify-content: center;
         gap: 1rem;
-        overflow: scroll;
     }
 
     .front {

--- a/static/style.css
+++ b/static/style.css
@@ -81,6 +81,7 @@ span {
     background: linear-gradient(to right,
             var(--accent-color),
             var(--secondary-color));
+    -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
     font-weight: 700;


### PR DESCRIPTION
## Add -webkit- support for background-clip

![Screenshot_20221118_170154](https://user-images.githubusercontent.com/46286940/202817267-7b0b592e-2ff1-49a1-9d21-27d96748e717.png)
[as shown here](https://caniuse.com/background-clip-text), Chromium based browsers still need `-webkit-` prefix for `background-clip`.
##  Remove non-necessary scroll attribute

Also, I removed scroll attribute so that there is no scroll bar surrounding the link buttons:
![Screenshot_20221118_170124](https://user-images.githubusercontent.com/46286940/202817216-d09f7f00-e7ba-445e-98fc-0002cdd78a00.png)